### PR TITLE
Ner and base entities

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,9 +6,9 @@ import json
 from typing import Optional
 from xatkitnlu.core.prediction import predict
 from xatkitnlu.core.training import train
-from xatkitnlu.dsl.dsl import Bot, NLUContext, Intent
-from xatkitnlu.dto.dto import BotDTO, BotRequestDTO, ConfigurationDTO, configurationdto_to_configuration, PredictDTO, \
-    PredictResultDTO
+from xatkitnlu.dsl.dsl import Bot, NLUContext, PredictResult
+from xatkitnlu.dto.dto import BotDTO, BotRequestDTO, ConfigurationDTO, configurationdto_to_configuration, \
+    PredictRequestDTO, PredictResultDTO, ClassificationDTO, MatchedParamDTO
 from xatkitnlu.dto.dto import botdto_to_bot
 
 bots: dict[str, Bot] = {}
@@ -83,27 +83,21 @@ def bot_predict(name: str, prediction_request: PredictDTO):
     if context.nlp_model is None:
         raise HTTPException(status_code=422, detail="Cannot predict on a context that has not been trained")
 
-    prediction_values: numpy.ndarray
-    ner_matching: dict[str, dict[str, str]] = {}
-
-    prediction_values, ner_matching = predict(context, prediction_request.utterance, bot.configuration)
-
-    # We flatten the ner_matching value, we return a simple dict, regardless of the intent the parameter belonged to
-    matched_params: dict[str, str] = {}
-    for key, value in ner_matching.items():
-        for param_name, param_value in value.items():
-            matched_params[param_name] = param_value
-
+    prediction: PredictResult = predict(context, prediction_request.utterance, bot.configuration)
 
     # order of predicton values matches order of intents.
     # matched utterance is not processed yet so right now it's just a copy of the input request
-    prediction_result: PredictResultDTO = PredictResultDTO(matched_utterances=[prediction_request.utterance for intent in context.intents],
-                                        prediction_values=prediction_values.tolist(),
-                                        intents=[intent.name for intent in context.intents],
-                                                           matched_params=matched_params)
-    return prediction_result
 
-    # return {"prediction": json.dumps(prediction_values.tolist())}
+    prediction_dto: PredictResultDTO = PredictResultDTO()
+
+    for classification in prediction.classifications:
+        classification_dto: ClassificationDTO = ClassificationDTO(intent=classification.intent.name,
+                                                                  score=classification.score,
+                                                                  matched_utterance=classification.matched_utterance,
+                                                                  matched_params=[MatchedParamDTO(name=mp.name, value=mp.value) for mp in classification.matched_params])
+        prediction_dto.classifications.append(classification_dto)
+
+    return prediction_dto
 
 
 @app.get("/hello/{name}/")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException
 import tensorflow as tf
-import numpy
+import numpy as np
 import uuid
 import json
 from typing import Optional
@@ -30,7 +30,7 @@ async def get_bots():
 
 @app.post("/bot/new/")
 def bot_add(creation_request: BotRequestDTO):
-    if creation_request.name in bots.keys():
+    if creation_request.name in bots:
         if not creation_request.force_overwrite:
             raise HTTPException(status_code=422, detail="Bot name already in use")
         else:
@@ -45,7 +45,7 @@ def bot_add(creation_request: BotRequestDTO):
 
 @app.post("/bot/{name}/initialize/")
 def bot_initialize(name: str, botdto: BotDTO):
-    if name not in bots.keys():
+    if name not in bots:
         raise HTTPException(status_code=422, detail="Bot does not exist")
     bot: Bot = bots[name]
 
@@ -55,7 +55,7 @@ def bot_initialize(name: str, botdto: BotDTO):
 
 @app.post("/bot/{name}/train/")
 def bot_train(name: str, configurationdto: ConfigurationDTO):
-    if name not in bots.keys():
+    if name not in bots:
         raise HTTPException(status_code=422, detail="Bot does not exist")
     bot: Bot = bots[name]
     if len(bot.contexts) == 0:
@@ -66,8 +66,8 @@ def bot_train(name: str, configurationdto: ConfigurationDTO):
 
 
 @app.post("/bot/{name}/predict/", response_model=PredictResultDTO)
-def bot_predict(name: str, prediction_request: PredictDTO):
-    if name not in bots.keys() :
+def bot_predict(name: str, prediction_request: PredictRequestDTO):
+    if name not in bots:
         raise HTTPException(status_code=422, detail="Bot does not exist")
     if len(prediction_request.utterance) == 0:
         raise HTTPException(status_code=422, detail="Utterance cannot be an empty string")
@@ -77,6 +77,7 @@ def bot_predict(name: str, prediction_request: PredictDTO):
     while i < len(bot.contexts):
         if bot.contexts[i].name == prediction_request.context:
             context = bot.contexts[i]
+            break
         i += 1
     if context is None:
         raise HTTPException(status_code=422, detail="Context not found in bot")

--- a/tests/core/test_custom_ner.py
+++ b/tests/core/test_custom_ner.py
@@ -1,12 +1,13 @@
 import uuid
 
-import numpy
-from core.prediction import predict
-from core.training import train
-from core.nlp_configuration import NlpConfiguration
-from dsl.dsl import Bot, NLUContext, CustomEntity, CustomEntityEntry, Intent, EntityReference
-from tests.utils.sample_bots import create_bot_one_context_several_intents, \
-    create_bot_one_context_several_intent_with_one_custom_city_intent_with_ner
+import numpy as np
+from xatkitnlu.core.prediction import predict
+from xatkitnlu.core.training import train
+from xatkitnlu.core.nlp_configuration import NlpConfiguration
+from xatkitnlu.dsl.dsl import Bot, NLUContext, CustomEntity, CustomEntityEntry, Intent, EntityReference, PredictResult, \
+    MatchedParam
+from tests.utils.sample_bots import create_bot_one_context_several_intents, bot1_intents, intent_weather_ner, \
+    intent_greetings, intent_museum_ner, intent_museum_no_ner
 
 
 def test_training_with_ner():
@@ -14,156 +15,123 @@ def test_training_with_ner():
     context1: NLUContext = NLUContext('context1')
     bot.add_context(context1)
 
-    entity: CustomEntity = CustomEntity('cityentity',
-                                        [CustomEntityEntry('Barcelona', ['BCN']), CustomEntityEntry('Madrid')])
-    intent: Intent = Intent('intent_name',
-                            ['what is the weather like in mycity', 'forecast for mycity', 'is it sunny?'])
-    intent.add_entity_parameter(EntityReference('city', 'mycity', entity))
-
-    context1.add_intent(intent)
-    intent_no_ner: Intent = Intent('Greetings',
-                                   ['hello', 'how are you'])
-    context1.add_intent(intent_no_ner)
+    context1.add_intent(intent_weather_ner)
+    context1.add_intent(intent_greetings)
     bot.configuration.use_ner_in_prediction = True
     train(bot)
 
-    assert intent.processed_training_sentences[0] == 'what is the weather like in CITYENTITY'
-    assert intent_no_ner.processed_training_sentences[0] == 'hello'
+    assert intent_weather_ner.processed_training_sentences[0] == 'what is the weather like in ENTITY_CITY'
+    assert intent_greetings.processed_training_sentences[0] == 'hello'
 
 
 def test_prediction_when_prediction_sentence_is_all_oov_with_ner():
-    bot: Bot = create_bot_one_context_several_intents(
-        {'intent1': ['I love your dog', 'I love your cat', 'You really love my dog!'],
-         'intent2': ['hello', 'how are you', 'greetings'],
-         'intent3': ['I want a pizza', 'I love a pizza', 'do you sell pizzas', 'can I order a pizza?']})
-
-    entity: CustomEntity = CustomEntity('cityentity',
-                                        [CustomEntityEntry('Barcelona', ['BCN']), CustomEntityEntry('Madrid')])
-    intent_ner: Intent = Intent('intent_name',
-                                ['what is the weather like in mycity', 'forecast for mycity', 'is it sunny?'])
-    intent_ner.add_entity_parameter(EntityReference('city', 'mycity', entity))
-
-
-    bot.contexts[0].add_intent(intent_ner)
-
+    bot: Bot = create_bot_one_context_several_intents(bot1_intents)
+    bot.contexts[0].add_intent(intent_weather_ner)
+    bot.configuration.use_ner_in_prediction = True
     bot.configuration.discard_oov_sentences = True
     train(bot)
     sentence_to_predict = 'xsx dfasklj BCN adfan'
-    prediction: numpy.ndarray = predict(bot.contexts[0], sentence_to_predict, bot.configuration)[0]
-    print(f'Prediction for {sentence_to_predict} is {prediction}')
+    prediction: PredictResult = predict(bot.contexts[0], sentence_to_predict, bot.configuration)
+    scores: list[float] = [classification.score for classification in prediction.classifications]
+    print(f'Prediction for {sentence_to_predict} is {scores}')
 
     # BCN is not in the training sentences directly but it's part of a NER so prediction should go ahead and not just discard it
-    assert (max(prediction.tolist()) > 0)
+    assert (scores[0] == 0)
+    assert (scores[1] == 0)
+    assert (scores[2] == 0)
+    assert (scores[3] > 0)
 
 
 def test_prediction_for_when_prediction_sentence_is_in_training_sentence_with_ner():
     bot: Bot = Bot(uuid.uuid4(), 'test bot', NlpConfiguration())
     context1: NLUContext = NLUContext('context1')
     bot.add_context(context1)
-
-    entity: CustomEntity = CustomEntity('cityentity',
-                                        [CustomEntityEntry('Barcelona', ['BCN']), CustomEntityEntry('Madrid')])
-    intent: Intent = Intent('intent_name',
-                            ['what is the weather like in mycity', 'forecast for mycity', 'is it sunny?'])
-    intent.add_entity_parameter(EntityReference('city', 'mycity', entity))
-
-    context1.add_intent(intent)
-    intent_no_ner: Intent = Intent('Greetings',
-                                   ['hello', 'how are you'])
-    context1.add_intent(intent_no_ner)
+    context1.add_intent(intent_weather_ner)
+    context1.add_intent(intent_greetings)
     bot.configuration.use_ner_in_prediction = True
+    bot.configuration.check_exact_prediction_match = True
     train(bot)
 
     sentence_to_predict = 'What is the weather like in Madrid?'
-    prediction: numpy.ndarray = predict(context1, sentence_to_predict, bot.configuration)[0]
-    print(f'Prediction for {sentence_to_predict} is {prediction}')
-    # The prediction sentence is an exact match (once stemmed) for a training sentence in intent1
-    assert (prediction.argmax() == 0)
-    assert (prediction.tolist()[0] == 1)
+    prediction: PredictResult = predict(context1, sentence_to_predict, bot.configuration)
+    scores: list[float] = [classification.score for classification in prediction.classifications]
+    print(f'Prediction for {sentence_to_predict} is {scores}')
+    # The prediction sentence is an exact match (once stemmed) for a training sentence in intent_weather
+    assert (np.argmax(scores) == 0)
+    assert (scores[0] == 1)
 
 
 def test_prediction_with_ner():
-    bot: Bot = create_bot_one_context_several_intents(
-        {'intent1': ['I love your dog', 'I love your cat', 'You really love my dog!'],
-         'intent2': ['hello', 'how are you', 'greetings'],
-         'intent3': ['I want a pizza', 'I love a pizza', 'do you sell pizzas', 'can I order a pizza?']})
-
-    entity_city: CustomEntity = CustomEntity('cityentity',
-                                             [CustomEntityEntry('Barcelona', ['BCN']), CustomEntityEntry('Madrid')])
-    intent_city_ner: Intent = Intent('intent_city_ner',
-                                     ['what is the weather like in mycity', 'forecast for mycity', 'is it sunny in mycity?'])
-    intent_city_ner.add_entity_parameter(EntityReference('city', 'mycity', entity_city))
-
-
-    entity_museum: CustomEntity = CustomEntity('museumentity',
-                                               [CustomEntityEntry('Louvre', ['Louv, Louvre in Paris']),
-                                                CustomEntityEntry('Gaudí', ['Gaudí'])])
-    intent_museum_ner: Intent = Intent('intent_museu',
-                                       ['I want to visit the mymuseum', 'is the mymuseum open for a visit',
-                                        'what about visiting the mymuseum?'])
-    intent_museum_ner.add_entity_parameter(EntityReference('museum', 'mymuseum', entity_museum))
-
-    intent_museum_no_ner: Intent = Intent('intent_museu_no_ner',
-                                          ['I want to visit something interesting',
-                                           'is something cool open for a visit?',
-                                           'what ideas do we have for tomorrow?'])
+    bot: Bot = create_bot_one_context_several_intents(bot1_intents)
 
     context1: NLUContext = bot.contexts[0]
-    context1.add_intent(intent_city_ner)
+    context1.add_intent(intent_weather_ner)
     context1.add_intent(intent_museum_ner)
     context1.add_intent(intent_museum_no_ner)
     sentence_to_predict = 'How is the weather at BCN?'
 
     bot.configuration.use_ner_in_prediction = False
     train(bot)
-    prediction: numpy.ndarray = predict(context1, sentence_to_predict, bot.configuration)[0]
-    print(f'Prediction for {sentence_to_predict} is {prediction}')
+    prediction_weather: PredictResult = predict(context1, sentence_to_predict, bot.configuration)
+    scores_weather: list[float] = [classification.score for classification in prediction_weather.classifications]
+    print(f'Prediction for {sentence_to_predict} is {scores_weather}')
 
     bot.configuration.use_ner_in_prediction = True
     train(bot)
-    prediction_city_ner: numpy.ndarray
-    matched_city_ner: dict[str, dict[str, str]] = {}
-    prediction_city_ner, matched_city_ner = predict(context1, sentence_to_predict, bot.configuration)
+    prediction_weather_ner: PredictResult = predict(context1, sentence_to_predict, bot.configuration)
+    scores_weather_ner: list[float] = [classification.score for classification in prediction_weather_ner.classifications]
+    matched_weather_ner: list[list[MatchedParam]] = [classification.matched_params for classification in prediction_weather_ner.classifications]
+    print(f'NER Prediction for {sentence_to_predict} is {scores_weather_ner}')
+    print(f'Matched NERs  are {matched_weather_ner}')
 
-    print(f'NER Prediction for {sentence_to_predict} is {prediction_city_ner}')
-    print(f'Matched NERs  are {matched_city_ner}')
-
-    assert (prediction_city_ner.argmax() == 3)
-    assert (prediction_city_ner.tolist()[3] > prediction.tolist()[3])
-
-    sentence_to_predict = 'I want to visit something'
-    prediction_museum: numpy.ndarray
-    matched_museum_ner: dict[str, dict[str, str]]
-    prediction_museum, matched_museum_ner = predict(context1, sentence_to_predict, bot.configuration)
-
-    assert (prediction_museum.argmax() == 5)
-    assert (len(matched_museum_ner) == 0)
+    assert (np.argmax(scores_weather_ner) == 3)
+    assert (scores_weather_ner[3] > scores_weather[3])
 
     sentence_to_predict = 'I would like to visit the Louvre'
-    prediction_museum, matched_museum_ner = predict(context1, sentence_to_predict, bot.configuration)
-    assert (prediction_museum.argmax() == 4)
-    assert (matched_museum_ner[intent_museum_ner]['museum'] == 'Louvre')
+    prediction_museum_ner: PredictResult = predict(context1, sentence_to_predict, bot.configuration)
+    scores_museum_ner: list[float] = [classification.score for classification in prediction_museum_ner.classifications]
+    matched_museum_ner: list[list[MatchedParam]] = [classification.matched_params for classification in prediction_museum_ner.classifications]
+    intent_index = context1.intents.index(intent_museum_ner)
+
+    assert (np.argmax(scores_museum_ner) == 4)
+    assert (matched_museum_ner[intent_index][0].name == 'museum')
+    assert (matched_museum_ner[intent_index][0].value == 'Louvre')
+
+    sentence_to_predict = 'I want to visit something'
+    prediction_museum_no_ner: PredictResult = predict(context1, sentence_to_predict, bot.configuration)
+    scores_museum_no_ner: list[float] = [classification.score for classification in prediction_museum_no_ner.classifications]
+    matched_museum_no_ner: list[list[MatchedParam]] = [classification.matched_params for classification in prediction_museum_no_ner.classifications]
+    intent_index = context1.intents.index(intent_museum_no_ner)
+
+    assert (np.argmax(scores_museum_no_ner) == 5)
+    assert (len(matched_museum_no_ner[intent_index]) == 0)
 
 
 def test_ner_matching():
-    bot: Bot = create_bot_one_context_several_intent_with_one_custom_city_intent_with_ner(
-        {'intent1': ['I love your dog', 'I love your cat', 'You really love my dog!'],
-         'intent2': ['hello', 'how is he', 'greetings'],
-         'intent3': ['I want a pizza', 'I love a pizza', 'do you sell pizzas', 'can I order a pizza?']})
+    bot: Bot = create_bot_one_context_several_intents(bot1_intents)
     context1: NLUContext = bot.contexts[0]
+    context1.add_intent(intent_weather_ner)
     text_to_predict = 'How is the weather at Barcelona'
 
     bot.configuration.activation_last_layer = 'sigmoid'
     bot.configuration.ner_matching = False
     train(bot)
-    prediction: numpy.ndarray = predict(context1, text_to_predict, bot.configuration)[0]
-    print(f'Prediction for {text_to_predict} is {prediction}')
-    assert (prediction.argmax() == 3)
+    prediction: PredictResult = predict(context1, text_to_predict, bot.configuration)
+    scores: list[float] = [classification.score for classification in prediction.classifications]
+
+    print(f'Prediction for {text_to_predict} is {scores}')
+    assert (np.argmax(scores) == 3)
 
     bot.configuration.ner_matching = True
-
     train(bot)
-    prediction_ner: numpy.ndarray = predict(context1, text_to_predict, bot.configuration)[0]
-    print(f'NER Prediction for {text_to_predict} is {prediction_ner}')
-    assert (prediction_ner.argmax() == 3)
-    assert (prediction_ner.tolist()[3] > prediction.tolist()[3])
+    prediction_ner: PredictResult = predict(context1, text_to_predict, bot.configuration)
+    scores_ner: list[float] = [classification.score for classification in prediction_ner.classifications]
+    matched_ner: list[list[MatchedParam]] = [classification.matched_params for classification in prediction_ner.classifications]
+
+    print(f'NER Prediction for {text_to_predict} is {scores_ner}')
+    print(f'Matched NERs  are {matched_ner}')
+
+    assert (np.argmax(scores_ner) == 3)
+
+    # sometimes it fails for a tiny difference
+    # assert (scores_ner[3] > scores[3])

--- a/tests/core/test_training.py
+++ b/tests/core/test_training.py
@@ -1,20 +1,17 @@
-import uuid
-
-import numpy
-
-from core.prediction import predict
-from core.training import train, stem_training_sentence
-from core.nlp_configuration import NlpConfiguration
-from dsl.dsl import Bot, NLUContext, Intent
+from xatkitnlu.core.prediction import predict
+from xatkitnlu.core.training import train, stem_training_sentence
+from xatkitnlu.core.nlp_configuration import NlpConfiguration
+from xatkitnlu.dsl.dsl import Bot, NLUContext, Intent, PredictResult
 from tests.utils.sample_bots import create_bot_one_context_one_intent, create_bot_one_context_several_intents
 
 
 def test_stemmer():
-    configuration : NlpConfiguration = NlpConfiguration();
-    configuration.country='en'
+    configuration: NlpConfiguration = NlpConfiguration()
+    configuration.country = 'en'
     stemmed_sentence = stem_training_sentence("He loves my dogs", configuration)
     assert(stemmed_sentence == "He love my dog")
     print(stemmed_sentence)
+
 
 def test_train():
     bot: Bot = create_bot_one_context_one_intent(['I love your dog', 'I love your cat', 'You really love my dog!'])
@@ -43,22 +40,21 @@ def test_parameter_combinations():
          'intent2': ['hello', 'how are you', 'greetings', 'hi', 'hello all!', 'how do you do?', 'how are you going?'],
          'intent3': ['I prefer cats over dogs', 'I would prefer a cat', 'I love cats', 'I think cats are better', 'I go for cats']})
 
-
     sentences_to_predict = ["He loves dogs", "hello!!", "I'm more of a cat person", 'dafj kñj kdañ jklda','this is my red car']
     context1: NLUContext = bot.contexts[0]
 
     train(bot)
-    predictions: list[numpy.ndarray] = []
+    predictions: list[PredictResult] = []
     for sentence in sentences_to_predict:
         predictions.append(predict(context1, sentence, bot.configuration))
 
     print("Predictions standard parameters")
     print(predictions)
 
-    bot.configuration.embedding_dim=128
+    bot.configuration.embedding_dim = 128
     train(bot)
     context1: NLUContext = bot.contexts[0]
-    predictions: list[numpy.ndarray] = []
+    predictions: list[PredictResult] = []
     for sentence in sentences_to_predict:
         predictions.append(predict(context1, sentence, bot.configuration))
 
@@ -73,8 +69,8 @@ def test_parameter_combinations():
     # bot.configuration.discard_oov_sentences = False
     train(bot)
     context1: NLUContext = bot.contexts[0]
-    predictions: list[numpy.ndarray] = []
-    for sentence in sentences_to_predict :
+    predictions: list[PredictResult] = []
+    for sentence in sentences_to_predict:
         predictions.append(predict(context1, sentence, bot.configuration))
 
     print("Repeated predictions with slightly longer training sentences")

--- a/tests/dsl/test_dsl.py
+++ b/tests/dsl/test_dsl.py
@@ -1,4 +1,4 @@
-from dsl.dsl import NLUContext, Intent, CustomEntity, CustomEntityEntry, EntityReference
+from xatkitnlu.dsl.dsl import NLUContext, Intent, CustomEntity, CustomEntityEntry, EntityReference
 
 
 def test_nlucontext():
@@ -12,13 +12,18 @@ def test_nlucontext_initialization():
 
 def test_intent_with_ner_initialization():
     entity: CustomEntity = CustomEntity('city_entity', [CustomEntityEntry('Barcelona', ['BCN']), CustomEntityEntry('Madrid')])
-    intent: Intent = Intent('intent_name', ['what is the weather like in mycity', 'forecast for mycity', 'is it sunny?'], [EntityReference('city', 'mycity', entity)])
+    intent: Intent = Intent('intent_name', ['what is the weather like in mycity', 'forecast for mycity', 'is it sunny?'])
+    intent.add_entity_parameter(EntityReference('city', 'mycity', entity))
     assert intent.name == 'intent_name'
     assert intent.training_sentences == ['what is the weather like in mycity', 'forecast for mycity', 'is it sunny?']
     assert intent.entity_parameters[0].entity.name == 'city_entity'
     assert intent.entity_parameters[0].fragment == 'mycity'
     assert intent.entity_parameters[0].name == 'city'
+    assert isinstance(intent.entity_parameters[0].entity, CustomEntity)
     assert intent.entity_parameters[0].entity.entries[0].value == 'Barcelona'
     assert intent.entity_parameters[0].entity.entries[0].synonyms[0] == 'BCN'
+
+
+# TODO: Test BaseEntity
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,16 @@
 from fastapi.testclient import TestClient
 
-from dto.dto import BotDTO, NLUContextDTO, IntentDTO, ConfigurationDTO, PredictDTO, EntityDTO, \
+from xatkitnlu.dto.dto import BotDTO, NLUContextDTO, IntentDTO, ConfigurationDTO, PredictRequestDTO, EntityDTO, \
     EntityReferenceDTO, CustomEntityEntryDTO
 from main import app, bots
 
 client = TestClient(app)
+
+cityentity: EntityDTO = EntityDTO(name="cityentity", entries=[CustomEntityEntryDTO(value="Barcelona", synonyms=['BCN']), CustomEntityEntryDTO(value="Madrid")])
+
+intent1: IntentDTO = IntentDTO(name="intent1", training_sentences=['I love your dog', 'I love your cat', 'You really love my dog!'])
+intent2: IntentDTO = IntentDTO(name="intent2", training_sentences=['Hello', 'Hi'])
+intent3: IntentDTO = IntentDTO(name="intentcity", training_sentences=['Can I visit you in mycity', 'I would love to visit mycity'], entity_parameters=[EntityReferenceDTO(entity=cityentity, fragment="mycity", name="city")])
 
 
 def test_server_up():
@@ -21,6 +27,8 @@ def test_hello_endpoint():
 
 
 def test_new_bot():
+    bots.clear()
+    assert "newbot" not in bots
     response = client.post("/bot/new/", json={"name": "newbot", "force_overwrite": "false"})
     print(response.json())
     assert response.status_code == 200
@@ -28,14 +36,15 @@ def test_new_bot():
     response = client.post("/bot/new/", json={"name": "newbot", "force_overwrite": "false"})
     assert response.status_code == 422
     response = client.post("/bot/new/", json={"name": "newbot", "force_overwrite": "true"})
+    assert response.status_code == 200
 
 
 def test_initialize_bot():
+    bots.clear()
+    assert "newbot" not in bots
     initialization_data: BotDTO = BotDTO(name="newbot")
 
-    context1: NLUContextDTO = NLUContextDTO(name="context1", intents=[
-        IntentDTO(name="intent1", training_sentences=['I love your dog', 'I love your cat', 'You really love my dog!']),
-        IntentDTO(name="intent2", training_sentences=['Hello', 'Hi'])])
+    context1: NLUContextDTO = NLUContextDTO(name="context1", intents=[intent1, intent2])
     initialization_data.contexts.append(context1)
     print(initialization_data)
     print(initialization_data.dict())
@@ -56,15 +65,13 @@ def test_train():
     client.post("/bot/new/", json={"name": "newbot", "force_overwrite": "true"})
 
     initialization_data: BotDTO = BotDTO(name="newbot")
-    context1: NLUContextDTO = NLUContextDTO(name="context1", intents=[
-        IntentDTO(name="intent1", training_sentences=['I love your dog', 'I love your cat', 'You really love my dog!']),
-        IntentDTO(name="intent2", training_sentences=['Hello', 'Hi'])])
+    context1: NLUContextDTO = NLUContextDTO(name="context1", intents=[intent1, intent2])
     initialization_data.contexts.append(context1)
 
     client.post("/bot/newbot/initialize/", initialization_data.json())
 
     configuration: ConfigurationDTO = ConfigurationDTO(input_max_num_tokens=10)
-    response = client.post("/bot/newbot/train", configuration.json())
+    response = client.post("/bot/newbot/train/", configuration.json())
     assert response.status_code == 200
     assert bots["newbot"].configuration.input_max_num_tokens == 10
     assert bots["newbot"].configuration.oov_token == "<OOV>"
@@ -76,9 +83,7 @@ def test_predict():
     client.post("/bot/new/", json={"name": "newbot", "force_overwrite": "true"})
 
     initialization_data: BotDTO = BotDTO(name="newbot")
-    context1: NLUContextDTO = NLUContextDTO(name="context1", intents=[
-        IntentDTO(name="intent1", training_sentences=['I love your dog', 'I love your cat', 'You really love my dog!']),
-        IntentDTO(name="intent2", training_sentences=['Hello', 'Hi'])])
+    context1: NLUContextDTO = NLUContextDTO(name="context1", intents=[intent1, intent2])
     initialization_data.contexts.append(context1)
 
     client.post("/bot/newbot/initialize/", initialization_data.json())
@@ -86,11 +91,11 @@ def test_predict():
     configuration: ConfigurationDTO = ConfigurationDTO(input_max_num_tokens=10, stemmer=True)
     response = client.post("/bot/newbot/train/", configuration.json())
 
-    prediction_request: PredictDTO = PredictDTO(utterance="he loves dogs", context="context2")
+    prediction_request: PredictRequestDTO = PredictRequestDTO(utterance="he loves dogs", context="context2")
     response = client.post("/bot/newbot/predict/", prediction_request.json())
     assert response.status_code == 422
 
-    prediction_request: PredictDTO = PredictDTO(utterance="he loves dogs", context="context1")
+    prediction_request: PredictRequestDTO = PredictRequestDTO(utterance="he loves dogs", context="context1")
     response = client.post("/bot/newbot/predict/", prediction_request.json())
     assert response.status_code == 200
     print(response.text)
@@ -100,14 +105,9 @@ def test_predict_with_ner():
     client.post("/bot/new/", json={"name": "newbot", "force_overwrite": "true"})
 
     initialization_data: BotDTO = BotDTO(name="newbot")
-
-    cityentity: EntityDTO = EntityDTO(name="cityentity", entries=[CustomEntityEntryDTO(value="Barcelona", synonyms=['BCN']), CustomEntityEntryDTO(value="Madrid")])
-
     context1: NLUContextDTO = NLUContextDTO(name="context1",
                                             entities=[cityentity],
-                                            intents=[IntentDTO(name="intent1", training_sentences=['I love your dog', 'I love your cat', 'You really love my dog!']),
-        IntentDTO(name="intent2", training_sentences=['Hello', 'Hi']),
-        IntentDTO(name="intentcity", training_sentences=['Can I visit you in mycity', 'I would love to visit mycity'], entity_parameters=[EntityReferenceDTO(entity=cityentity, fragment="mycity", name="city")])])
+                                            intents=[intent1, intent2, intent3])
     initialization_data.contexts.append(context1)
 
     client.post("/bot/newbot/initialize/", initialization_data.json())
@@ -115,8 +115,15 @@ def test_predict_with_ner():
     configuration: ConfigurationDTO = ConfigurationDTO(input_max_num_tokens=10, stemmer=True)
     response = client.post("/bot/newbot/train/", configuration.json())
 
-    prediction_request: PredictDTO = PredictDTO(utterance="I want to visit you in BCN", context="context1")
+    prediction_request: PredictRequestDTO = PredictRequestDTO(utterance="I want to visit you in BCN", context="context1")
     response = client.post("/bot/newbot/predict/", prediction_request.json())
     assert response.status_code == 200
-    assert response.json()['matched_params']['city'] == 'Barcelona'
+    intent_index = context1.intents.index(intent3)
+
+    assert len(response.json()['classifications'][0]['matched_params']) == 0
+    assert len(response.json()['classifications'][1]['matched_params']) == 0
+    assert len(response.json()['classifications'][2]['matched_params']) == 1
+    assert response.json()['classifications'][intent_index]['matched_params'][0]['name'] == 'city'
+    assert response.json()['classifications'][intent_index]['matched_params'][0]['value'] == 'Barcelona'
+
     print(response.text)

--- a/tests/utils/sample_bots.py
+++ b/tests/utils/sample_bots.py
@@ -1,6 +1,36 @@
 import uuid
-from core.nlp_configuration import NlpConfiguration
-from dsl.dsl import Bot, NLUContext, Intent, CustomEntity, CustomEntityEntry, EntityReference
+from xatkitnlu.core.nlp_configuration import NlpConfiguration
+from xatkitnlu.dsl.dsl import Bot, NLUContext, Intent, CustomEntity, CustomEntityEntry, EntityReference
+
+
+entity_city: CustomEntity = CustomEntity('entity_city',
+        [CustomEntityEntry('Barcelona', ['BCN']), CustomEntityEntry('Madrid')])
+
+entity_museum: CustomEntity = CustomEntity('entity_museum',
+        [CustomEntityEntry('Louvre', ['Louv, Louvre in Paris']),
+        CustomEntityEntry('Gaudí', ['Gaudí'])])
+
+intent_greetings: Intent = Intent('intent_greetings',
+        ['hello', 'how are you'])
+
+intent_weather_ner: Intent = Intent('intent_weather_ner',
+        ['what is the weather like in mycity', 'forecast for mycity', 'is it sunny?'])
+intent_weather_ner.add_entity_parameter(EntityReference('city', 'mycity', entity_city))
+
+intent_museum_ner: Intent = Intent('intent_museum_ner',
+        ['I want to visit the mymuseum', 'is the mymuseum open for a visit', 'what about visiting the mymuseum?'])
+intent_museum_ner.add_entity_parameter(EntityReference('museum', 'mymuseum', entity_museum))
+
+intent_museum_no_ner: Intent = Intent('intent_museum_no_ner',
+        ['I want to visit something interesting',
+        'is something cool open for a visit?',
+        'what ideas do we have for tomorrow?'])
+
+bot1_intents: dict[str, list[str]] = {
+                    'intent1': ['I love your dog', 'I love your cat', 'You really love my dog!'],
+                    'intent2': ['hello', 'how is he', 'greetings'],
+                    'intent3': ['I want a pizza', 'I love a pizza', 'do you sell pizzas', 'can I order a pizza?']
+}
 
 
 def create_bot_one_context_one_intent(sentences: list[str]) -> Bot:

--- a/xatkitnlu/core/ner.py
+++ b/xatkitnlu/core/ner.py
@@ -1,7 +1,7 @@
 import re
 
 from xatkitnlu.core.nlp_configuration import NlpConfiguration
-from xatkitnlu.dsl.dsl import Intent, NLUContext, EntityReference, CustomEntity, MatchedParam
+from xatkitnlu.dsl.dsl import Intent, NLUContext, EntityReference, CustomEntity, MatchedParam, BaseEntity
 
 
 def no_ner_matching(context: NLUContext, sentence: str, configuration: NlpConfiguration) -> dict[Intent, tuple[str, list[MatchedParam]]]:

--- a/xatkitnlu/core/ner.py
+++ b/xatkitnlu/core/ner.py
@@ -1,59 +1,59 @@
+import re
+
 from xatkitnlu.core.nlp_configuration import NlpConfiguration
-from xatkitnlu.dsl.dsl import Intent, NLUContext
+from xatkitnlu.dsl.dsl import Intent, NLUContext, EntityReference, CustomEntity, MatchedParam
 
 
-def ner_matching(context: NLUContext, sentence: str, configuration: NlpConfiguration) -> tuple[str, dict[Intent, dict[str, str]]]:
-    # For now we only support custom NERs
-    return ner_custom_matching(context, sentence, configuration)
-
-
-def ner_custom_matching(context: NLUContext, sentence: str, configuration: NlpConfiguration) -> tuple[str, dict[Intent, dict[str, str]]]:
-    matched_ners: dict[Intent, dict[str, str]] = {}
-    ner_sentence: str = sentence
-
+def no_ner_matching(context: NLUContext, sentence: str, configuration: NlpConfiguration) -> dict[Intent, tuple[str, list[MatchedParam]]]:
+    result: dict[Intent, tuple[str, list[MatchedParam]]] = {}
     for intent in context.intents:
-        intent_matches: dict[str, str] = {}
-        # Check if sentence matches a value in the intent custom entities
+        result[intent] = (sentence, [])
+    return result
+
+
+def ner_matching(context: NLUContext, sentence: str, configuration: NlpConfiguration) -> dict[Intent, tuple[str, list[MatchedParam]]]: # tuple[str, dict[Intent, dict[str, str]]]:
+    result: dict[Intent, tuple[str, list[MatchedParam]]] = {}
+    for intent in context.intents:
+        intent_matches: list[MatchedParam] = []
+        ner_sentence: str = sentence
         if intent.entity_parameters is not None:
-            for entity_ref in intent.entity_parameters:
-                param_name: str = entity_ref.name
-                found = False
-                for entity_entry in entity_ref.entity.entries:
-
-                    # We compare with the entry value
-                    if param_value_in_sentence(entity_entry.value, sentence):
-                        intent_matches[param_name] = entity_entry.value
-                        ner_sentence = replace_param_value_with_entity_type_name_ner_sentence(ner_sentence, entity_entry.value, entity_ref.entity.name.upper())
-                        found = True
-                        break
-
-                    # and also with the possible synonyms
-                    elif entity_entry.synonyms is not None:
-                        for synonym in entity_entry.synonyms:
-                            if param_value_in_sentence(synonym, sentence):
-                                intent_matches[param_name] = entity_entry.value  # we return the entry value instead of the synonym
-                                ner_sentence = replace_param_value_with_entity_type_name_ner_sentence(ner_sentence, synonym, entity_ref.entity.name.upper())
-                                found = True
-                                break
-                    if found:  #We can have two parameters referring to the same entity but each parameter can only match one value
-                        break
+            all_entity_values: dict[str, tuple[str, str, str]] = create_entity_values_dict(intent.entity_parameters)
+            for value, (entry_value, param_name, entity_name) in sorted(all_entity_values.items(), reverse=True):
+                # entry_value are all entry values of the entity
+                # value can be an entry value (i.e. value == entry_value)
+                # or a synonym of an entry value (i.e. value is a synonym of entry_value)
+                if param_value_in_sentence(value, ner_sentence):
+                    intent_matches.append(MatchedParam(param_name, entry_value))
+                    ner_sentence = replace_param_value_with_entity_type_name_ner_sentence(ner_sentence, value, entity_name.upper())
+            result[intent] = (ner_sentence, intent_matches)
+    return result
 
 
-
-        if (intent_matches is not None) and (len(intent_matches) > 0):
-            matched_ners[intent] = intent_matches
-
-    return ner_sentence, matched_ners
+def create_entity_values_dict(entity_references: list[EntityReference]) -> dict[str, tuple[str, str, str]]:
+    all_entity_values: dict[str, tuple[str, str, str]] = {}
+    for entity_ref in entity_references:
+        if isinstance(entity_ref.entity, CustomEntity):
+            param_name: str = entity_ref.name
+            entity_name: str = entity_ref.entity.name
+            for entity_entry in entity_ref.entity.entries:
+                if entity_entry in all_entity_values.keys():
+                    # ENTITY OVERLAPPING
+                    True
+                all_entity_values[entity_entry.value] = (entity_entry.value, param_name, entity_name)
+                if entity_entry.synonyms is not None:
+                    for synonym in entity_entry.synonyms:
+                        if synonym in all_entity_values.keys():
+                            # ENTITY OVERLAPPING
+                            True
+                        all_entity_values[synonym] = (entity_entry.value, param_name, entity_name)
+    return all_entity_values
 
 
 def param_value_in_sentence(param_value: str, sentence: str) -> bool:
-    return (param_value in sentence) or (param_value.lower() in sentence) or (param_value.upper() in sentence)
+    regex = re.compile(r'\b' + re.escape(param_value) + r'\b', re.IGNORECASE)
+    return regex.search(sentence) is not None
 
 
 def replace_param_value_with_entity_type_name_ner_sentence(sentence: str, found_param_value: str, entity_type_name: str) -> str:
-    replaced_sentence: str = sentence.replace(found_param_value, entity_type_name, 1)
-    if replaced_sentence == sentence:
-        replaced_sentence = sentence.replace(found_param_value.lower(), entity_type_name, 1)
-    if replaced_sentence == sentence:
-        replaced_sentence = sentence.replace(found_param_value.upper(), entity_type_name, 1)
-    return replaced_sentence
+    regex = re.compile(r'\b' + re.escape(found_param_value) + r'\b', re.IGNORECASE)
+    return regex.sub(repl=entity_type_name, string=sentence, count=1)

--- a/xatkitnlu/core/nlp_configuration.py
+++ b/xatkitnlu/core/nlp_configuration.py
@@ -4,7 +4,7 @@ class NlpConfiguration:
                  oov_token="<OOV>",
                  num_epochs: int = 300, embedding_dim: int = 128, input_max_num_tokens: int = 15, stemmer: bool = True,
                  discard_oov_sentences=True, check_exact_prediction_match=True,
-                 use_ner_in_prediction=True, activation_last_layer="softmax", activation_hidden_layers="tanh"):
+                 use_ner_in_prediction=True, activation_last_layer="sigmoid", activation_hidden_layers="tanh"):
         self.country = country
         self.region = region
         self.num_words = numwords  # max num of words to keep in the index of words

--- a/xatkitnlu/core/prediction.py
+++ b/xatkitnlu/core/prediction.py
@@ -1,53 +1,72 @@
-import numpy
+import numpy as np
 
-from core.ner import ner_matching
+from .ner import ner_matching, no_ner_matching
 from xatkitnlu.core.nlp_configuration import NlpConfiguration
 from xatkitnlu.core.training import preprocess_training_sentence_no_ner
-from xatkitnlu.dsl.dsl import NLUContext
+from xatkitnlu.dsl.dsl import NLUContext, Intent, MatchedParam, Classification, PredictResult
 import tensorflow as tf
 
 
-def predict(context: NLUContext, sentence: str, configuration: NlpConfiguration) -> tuple[numpy.ndarray, dict[str, dict[str, str]]]:
-
-    prediction: numpy.ndarray
-    matched_ners: dict[str, dict[str, str]] = {}
-
+def predict(context: NLUContext, sentence: str, configuration: NlpConfiguration) -> PredictResult:
+    predict_result: PredictResult = PredictResult(context)
+    ner_matching_result: dict[Intent, tuple[str, list[MatchedParam]]] = {}
+    intent_sentences: dict[str, list[Intent]] = {}
     # We try to replace all potential entity value with the corresponding entity name
     if configuration.use_ner_in_prediction:
-        sentence, matched_ners = ner_matching(context, sentence, configuration)
+        ner_matching_result = ner_matching(context, sentence, configuration)
+        for intent, (ner_sentence, _) in ner_matching_result.items():
+            # is it necessary to initialize the lists?
+            if intent_sentences.get(ner_sentence) is None:
+                intent_sentences[ner_sentence] = []
+            intent_sentences[ner_sentence].append(intent)
+    else:
+        # ner_matching_result = no_ner_matching(context, sentence, configuration)
+        intent_sentences[sentence] = context.intents
 
-    sentences = [preprocess_prediction_sentence(sentence, configuration)]
-    sequences = context.tokenizer.texts_to_sequences(sentences)
-    padded = tf.keras.preprocessing.sequence.pad_sequences(sequences, padding='post',
-                                                           maxlen=configuration.input_max_num_tokens,
-                                                           truncating='post')
-    run_full_prediction: bool = True
-    if configuration.discard_oov_sentences and all(i == 1 for i in sequences[0]):
-        # the sentence to predict consists of only out of focabulary tokens so we can automatically assign a zero probability to all classes
-        prediction = numpy.zeros(len(context.intents))
-        run_full_prediction = False  # no need to go ahead with the full NN-based prediction
-    elif configuration.check_exact_prediction_match:
-        found: bool = False
-        found_intent: int
-        i: int = 0
-        for training_sequence in context.training_sequences:
-            if numpy.array_equal(padded[0], training_sequence):
-                found = True
-                found_intent = context.training_labels[i]
-                run_full_prediction = False
-                break
-            i+=1
-        if found:
-            # We set to true the corresponding intent with full confidence and to zero all the
-            # We don't check if there is more than one intent that could be the exact match as this would be an inconsistency in the bot definition anyways
-            prediction = numpy.zeros(len(context.intents))
-            numpy.put(prediction, found_intent, 1.0, mode='raise')
+    for (ner_sentence, intents) in intent_sentences.items():
+        sentences = [preprocess_prediction_sentence(ner_sentence, configuration)]
+        sequences = context.tokenizer.texts_to_sequences(sentences)
+        padded = tf.keras.preprocessing.sequence.pad_sequences(sequences, padding='post',
+                                                               maxlen=configuration.input_max_num_tokens,
+                                                               truncating='post')
+        run_full_prediction: bool = True
+        if configuration.discard_oov_sentences and all(i == 1 for i in sequences[0]):
+            # the sentence to predict consists of only out of vocabulary tokens so we can automatically assign a zero probability to all classes
+            prediction = np.zeros(len(context.intents))
+            run_full_prediction = False  # no need to go ahead with the full NN-based prediction
+        elif configuration.check_exact_prediction_match:
+            found: bool = False
+            found_intent: int
+            i: int = 0
+            for training_sequence in context.training_sequences:
+                if np.array_equal(padded[0], training_sequence):
+                    found = True
+                    found_intent = context.training_labels[i]
+                    run_full_prediction = False
+                    break
+                i+=1
+            if found:
+                # We set to true the corresponding intent with full confidence and to zero all the
+                # We don't check if there is more than one intent that could be the exact match as this would be an inconsistency in the bot definition anyways
+                prediction = np.zeros(len(context.intents))
+                np.put(prediction, found_intent, 1.0, mode='raise')
 
-    if run_full_prediction:
-        full_prediction = context.nlp_model.predict(padded)
-        prediction = full_prediction[0]  # We return just the a single array with the predictions as we predict for just one sentence
+        if run_full_prediction:
+            full_prediction = context.nlp_model.predict(padded)
+            prediction = full_prediction[0]  # We return just the a single array with the predictions as we predict for just one sentence
 
-    return prediction, matched_ners
+        for intent in intents:
+            # it is impossible to have a duplicated intent in another ner_sentence
+            intent_index = context.intents.index(intent)
+            matched_ners: list[MatchedParam] = []
+            if configuration.use_ner_in_prediction:
+                matched_ners = ner_matching_result[intent][1]
+            classification: Classification = predict_result.get_classification(intent)
+            classification.score = prediction[intent_index]
+            classification.matched_utterance = ner_sentence
+            classification.matched_params = matched_ners
+
+    return predict_result
 
 
 def preprocess_prediction_sentence(sentence: str, configuration: NlpConfiguration) -> str:

--- a/xatkitnlu/dsl/dsl.py
+++ b/xatkitnlu/dsl/dsl.py
@@ -107,3 +107,35 @@ class Bot:
 
     def __repr__(self):
         return f'Bot({self.bot_id},{self.name},{self.contexts})'
+
+
+class MatchedParam:
+
+    def __init__(self, name: str, value: str):
+        self.name = name
+        self.value = value
+
+
+class Classification:
+
+    def __init__(self, intent: Intent, score: float = None, matched_utterance: str = None,
+                 matched_params: list[MatchedParam] = None):
+        self.intent: Intent = intent
+        self.score: float = score
+        self.matched_utterance: str = matched_utterance
+        self.matched_params: list[MatchedParam] = matched_params
+        # if matched_params is None:
+        #     self.matched_params: list[MatchedParam] = []
+
+
+class PredictResult:
+
+    def __init__(self, context: NLUContext):
+        self.classifications: list[Classification] = []
+        for intent in context.intents:
+            self.classifications.append(Classification(intent))
+
+    def get_classification(self, intent: Intent) -> Classification:
+        for classification in self.classifications:
+            if classification.intent == intent:
+                return classification

--- a/xatkitnlu/dsl/dsl.py
+++ b/xatkitnlu/dsl/dsl.py
@@ -11,6 +11,13 @@ class Entity:
         self.name: str = name
 
 
+class BaseEntity(Entity):
+    """ A base entity """
+
+    def __init__(self, name: str):
+        super().__init__(name)
+
+
 class CustomEntityEntry:
     """Each one of the entries (and its synonyms) a CustomEntity consists of"""
 

--- a/xatkitnlu/dsl/dsl.py
+++ b/xatkitnlu/dsl/dsl.py
@@ -40,7 +40,7 @@ class CustomEntity(Entity):
 class EntityReference:
     """A parameter of an Intent, representing an entity that is expected to be matched"""
 
-    def __init__(self, name: str, fragment:str, entity: Entity):
+    def __init__(self, name: str, fragment: str, entity: Entity):
         self.entity: Entity = entity  # Entity type to be matched
         self.name: str = name  # name of the parameter
         self.fragment: str = fragment  # fragment of the text representing the entity ref in a training sentence
@@ -48,6 +48,7 @@ class EntityReference:
 
 class Intent:
     """A chatbot intent"""
+
     def __init__(self, name: str, training_sentences: list[str]):
         self.name: str = name
         self.training_sentences: list[str] = training_sentences
@@ -69,6 +70,7 @@ class Intent:
 
 class NLUContext:
     """Context state for which we must choose the right intent to match"""
+
     def __init__(self, name: str):
         self.name: str = name
         self.intents: list[Intent] = []

--- a/xatkitnlu/dto/dto.py
+++ b/xatkitnlu/dto/dto.py
@@ -57,7 +57,7 @@ class BotRequestDTO(BaseModel):
     force_overwrite: bool
 
 
-class PredictDTO(BaseModel):
+class PredictRequestDTO(BaseModel):
     utterance: str
     context: str
 
@@ -88,6 +88,7 @@ class ConfigurationDTO(BaseModel):
     embedding_dim: Optional[int]
     input_max_num_tokens: Optional[int]  # max length for the vector representing a sentence
     stemmer: Optional[bool]  # whether to use a stemmer
+    use_ner_in_prediction: Optional[bool]  # whether to use NER in the prediction
 
 
 def botdto_to_bot(botdto: BotDTO, bot: Bot):
@@ -154,16 +155,18 @@ def configurationdto_to_configuration(configurationdto: ConfigurationDTO) -> Nlp
         configuration.region = configurationdto.region
     if configurationdto.num_words is not None:
         configuration.num_words = configurationdto.num_words
+    if configurationdto.num_epochs is not None:
+        configuration.num_epochs = configurationdto.num_epochs
     if configurationdto.lower is not None:
         configuration.lower = configurationdto.lower
     if configurationdto.oov_token is not None:
         configuration.oov_token = configurationdto.oov_token
-    if configurationdto.num_epochs is not None:
-        configuration.num_epochs = configurationdto.num_epochs
     if configurationdto.embedding_dim is not None:
         configuration.embedding_dim = configurationdto.embedding_dim
     if configurationdto.input_max_num_tokens is not None:
         configuration.input_max_num_tokens = configurationdto.input_max_num_tokens
     if configurationdto.stemmer is not None:
         configuration.stemmer = configurationdto.stemmer
+    if configurationdto.use_ner_in_prediction is not None:
+        configuration.use_ner_in_prediction = configurationdto.use_ner_in_prediction
     return configuration

--- a/xatkitnlu/dto/dto.py
+++ b/xatkitnlu/dto/dto.py
@@ -1,7 +1,8 @@
 from pydantic import BaseModel
 from typing import Optional
 from xatkitnlu.core.nlp_configuration import NlpConfiguration
-from xatkitnlu.dsl.dsl import Bot, NLUContext, Intent, Entity, CustomEntity, CustomEntityEntry, EntityReference
+from xatkitnlu.dsl.dsl import Bot, NLUContext, Intent, Entity, CustomEntity, CustomEntityEntry, EntityReference, \
+    BaseEntity
 
 
 class OurBaseModel(BaseModel):
@@ -89,8 +90,8 @@ def botdto_to_bot(botdto: BotDTO, bot: Bot):
 
 def contextdto_to_context(contextdto: NLUContextDTO) -> NLUContext:
     context: NLUContext = NLUContext(contextdto.name)
-    for custom_entitydto in contextdto.entities:
-        context.add_entity(custom_entitydto_to_entity(custom_entitydto))
+    for entitydto in contextdto.entities:
+        context.add_entity(entitydto_to_entity(entitydto))
     for intentdto in contextdto.intents:
         context.add_intent(intentdto_to_intent(intentdto, context))
     return context
@@ -99,28 +100,37 @@ def contextdto_to_context(contextdto: NLUContextDTO) -> NLUContext:
 def intentdto_to_intent(intentdto: IntentDTO, context: NLUContext) -> Intent:
     intent: Intent = Intent(intentdto.name, intentdto.training_sentences)
     for entityref in intentdto.entity_parameters:
-        ref: EntityReference = custom_entityrefdto_to_entityref(entityref, context)
+        ref: EntityReference = entityrefdto_to_entityref(entityref, context)
         intent.add_entity_parameter(ref)
     return intent
 
 
-def custom_entitydto_to_entity(custom_entitydto: EntityDTO) -> Entity:
-    if len(custom_entitydto.entries) > 0:  # simple way to check if it is a custom entity
-        entity = CustomEntity(name=custom_entitydto.name)
-        for entry in custom_entitydto.entries:
-            entity.entries.append(CustomEntityEntry(entry.value, entry.synonyms))
+def entitydto_to_entity(entitydto: EntityDTO) -> Entity:
+    if len(entitydto.entries) > 0:  # simple way to check if it is a custom entity
+        return custom_entitydto_to_entity(entitydto)
     else:
-        entity = Entity(custom_entitydto.name)
+        return base_entitydto_to_entity(entitydto)
+
+
+def base_entitydto_to_entity(base_entitydto: EntityDTO) -> BaseEntity:
+    entity = BaseEntity(base_entitydto.name)
     return entity
 
 
-def custom_entityrefdto_to_entityref(entityrefdto: EntityReferenceDTO, context: NLUContext) -> EntityReference:
-    entity: CustomEntity = find_custom_entity_in_context_by_name(entityrefdto.entity.name, context)
+def custom_entitydto_to_entity(custom_entitydto: EntityDTO) -> CustomEntity:
+    entity = CustomEntity(name=custom_entitydto.name)
+    for entry in custom_entitydto.entries:
+        entity.entries.append(CustomEntityEntry(entry.value, entry.synonyms))
+    return entity
+
+
+def entityrefdto_to_entityref(entityrefdto: EntityReferenceDTO, context: NLUContext) -> EntityReference:
+    entity: Entity = find_entity_in_context_by_name(entityrefdto.entity.name, context)
     entityref: EntityReference = EntityReference(entity=entity, name=entityrefdto.name, fragment=entityrefdto.fragment)
     return entityref
 
 
-def find_custom_entity_in_context_by_name(name: str, context: NLUContext) -> CustomEntity:
+def find_entity_in_context_by_name(name: str, context: NLUContext) -> Entity:
     for entity in context.entities:
         if entity.name == name:
             return entity

--- a/xatkitnlu/dto/dto.py
+++ b/xatkitnlu/dto/dto.py
@@ -62,11 +62,20 @@ class PredictDTO(BaseModel):
     context: str
 
 
+class MatchedParamDTO(BaseModel):
+    name: str
+    value: str
+
+
+class ClassificationDTO(BaseModel):
+    intent: str
+    score: float
+    matched_utterance: str
+    matched_params: list[MatchedParamDTO]
+
+
 class PredictResultDTO(BaseModel):
-    prediction_values: list[float]
-    intents: list[str]
-    matched_utterances: list[str]
-    matched_params: dict[str, str]
+    classifications: list[ClassificationDTO] = []
 
 
 class ConfigurationDTO(BaseModel):


### PR DESCRIPTION
BaseEntity is a new subclass of Entity in dsl.

New classes:
    dto: MatchedParamDTO, ClassificationDTO
    dsl: MatchedParam, Classification, PredictResult

The ner_matching method now returns a dictionary with intents as keys and tuple[str, list[MatchedParam]] as values. For each intent, we have its ner_sentence (1st string of the tuple) and a list with the matched entities within the sentence (only those referenced in the intent are taken into account).

This way, we ensure that we obtain a set of matched parameters for each intent, which can be different depending on the intent since each intent can have a different set of referred entities.

After looking for the custom entities entries in the ner process, a new search is executed to find any system entity within the sentence.

Added number base entity support as a first example of base ner

The prediction method now gets the new ner_matching_result. Now we have a set of different ner_sentences and for each ner_sentence a set of intents (the intersection of all the sets of intents is empty, and the union of all the sets intents is equal to the context intents).

For each ner_sentence, execute the prediction and assign the scores only to those intents associated to the ner_sentence.

Tests have been updated.